### PR TITLE
Update to dotnet 10 + nativeaot

### DIFF
--- a/SurfaceDuoDualBootKernelImagePatcher/SurfaceDuoDualBootKernelImagePatcher.csproj
+++ b/SurfaceDuoDualBootKernelImagePatcher/SurfaceDuoDualBootKernelImagePatcher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/SurfaceDuoDualBootKernelImagePatcher/SurfaceDuoDualBootKernelImagePatcher.csproj
+++ b/SurfaceDuoDualBootKernelImagePatcher/SurfaceDuoDualBootKernelImagePatcher.csproj
@@ -9,4 +9,8 @@
     <Platforms>AnyCPU;x86;x64;ARM64</Platforms>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
just built a new patched kernel, and decided to update the tool while I was at it.

produces lovely 1.2mb binaries instead of the ~10mb non aot binaries and extends the support date to 2027 and beyond

output is hash validated with the previous version of the tool